### PR TITLE
use the nxtedition/libplacebo formula for libplacebo

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -96,7 +96,7 @@ class Ffmpeg < Formula
   depends_on "libgsm" => :optional
   depends_on "libmodplug" => :optional
   depends_on "libopenmpt" => :optional
-  depends_on "libplacebo" => :optional
+  depends_on "nxtedition/libplacebo/libplacebo" => :optional
   depends_on "librist" => :optional
   depends_on "librsvg" => :optional
   depends_on "libsoxr" => :optional


### PR DESCRIPTION
Installs fine on my macbook pro, using libplacebo from nxtedition. But I haven't got any relevant filtergraphs for testing that libplacebo in ffmpeg actually works 